### PR TITLE
#169681829 Enable creating user profile on user signup

### DIFF
--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -3,6 +3,8 @@
 namespace App\Http\Controllers\Auth;
 
 use App\Model\User;
+use App\Profile;
+
 use App\Http\Controllers\Controller;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;
@@ -67,7 +69,7 @@ class RegisterController extends Controller
      */
     protected function create(array $data)
     {
-        return User::create([
+        $user = User::create([
             'firstname' => $data['firstname'],
             'lastname' => $data['lastname'],
             'role' => $data['role'],
@@ -75,5 +77,13 @@ class RegisterController extends Controller
             'password' => Hash::make($data['password']),
             'phonenumber' => $data['phonenumber'],
         ]);
+
+        Profile::create([
+            'user_id'   =>  $user->id,
+            'city'  =>  $data['city'] ?? '',
+            'district'   =>  $data['district'] ?? '',
+        ]);
+
+        return $user;
     }
 }

--- a/app/Model/Profile.php
+++ b/app/Model/Profile.php
@@ -1,0 +1,16 @@
+<?php namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+use App\User;
+
+class Profile extends Model {
+
+    protected $table = 'profiles';
+    protected $fillable = ['user_id', 'city', 'district'];
+
+    public function User()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+}

--- a/app/Model/User.php
+++ b/app/Model/User.php
@@ -5,6 +5,7 @@ namespace App\Model;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Foundation\Auth\User as Authenticatable;
+use App\Profile;
 
 class User extends Authenticatable implements MustVerifyEmail
 {
@@ -36,4 +37,10 @@ class User extends Authenticatable implements MustVerifyEmail
     protected $casts = [
         'email_verified_at' => 'datetime',
     ];
+
+    public function Profile()
+    {
+        return $this->hasOne(Profile::class);
+    }
+    
 }

--- a/database/migrations/2019_12_03_202009_create_profiles_table.php
+++ b/database/migrations/2019_12_03_202009_create_profiles_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateProfilesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+     public function up()
+     {
+         Schema::create('profiles', function (Blueprint $table) {
+             $table->bigIncrements('id');
+             $table->integer('user_id')->unsigned();
+             $table->string('city')->nullable();
+             $table->string('district')->nullable();
+             $table->timestamps();
+         });
+         Schema::table('profiles', function($table) {
+             $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+         });
+     }
+ 
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('profiles');
+    }
+}


### PR DESCRIPTION
#### What does this PR do?
- Enable creation of a Profile on user signup.
#### Description of Task to be completed?
- After a user has created an account, the profile of that person should be created automatically.
#### How should this be manually tested?
- Checkout to this branch
- Run migrations using `php artisan migrate`
- Start the server using `php artisan serve`
- Click on the get started now and create an account.
- Verify the created profile by checking your database
#### What are the relevant pivotal tracker stories?
[#169681829](https://www.pivotaltracker.com/story/show/169681829)
#### Screenshots.
![image](https://user-images.githubusercontent.com/22131999/70067470-6004ea00-15ff-11ea-8f48-219a9333a890.png)
Profile of user 6 in the database
![image](https://user-images.githubusercontent.com/22131999/70067361-3350d280-15ff-11ea-9d2b-7e47c1d296de.png)

#### Background context.
This is a backend task related to creating a One to One relationship between a User and Profile models.